### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ before_script:
   - composer install --prefer-dist --no-interaction
 
 script:
-  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p --extensions=php --standard=PSR2 ./src; fi"
+  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p --extensions=php --standard=ruleset.xml ./src; fi"

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -7,4 +7,8 @@
     <rule ref="Squiz.Classes.ValidClassName">
         <exclude-pattern>*/src/Zend*</exclude-pattern>
     </rule>
+
+    <rule ref="PSR1.Classes.ClassDeclaration">
+        <exclude-pattern>*/src/Zend*</exclude-pattern>
+    </rule>
 </ruleset>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset name="One-DB">
+    <description>Coding standard based on PSR-2 but relaxed in some areas</description>
+
+    <rule ref="PSR2" />
+
+    <rule ref="Squiz.Classes.ValidClassName">
+        <exclude-pattern>*/src/Zend*</exclude-pattern>
+    </rule>
+</ruleset>


### PR DESCRIPTION
Relax coding standards to permit the PEAR-style class names we will need for backwards compatibility with Zend_Db.